### PR TITLE
BUG007 - Corrigir modo de consulta de workflows para CI_feedback_time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ analytics-raw-data/
 **/*.log
 
 setup.py
+
+# Vim
+*.swp
+
+# ctags
+tags

--- a/src/cli/commands/cmd_extract.py
+++ b/src/cli/commands/cmd_extract.py
@@ -57,6 +57,7 @@ def command_extract(args):
         exit(1)
 
     label = args.get("label", None)
+    workflows = args.get("workflows", None)
 
     if label is not None and output_origin == "sonarqube":
         logger.error(
@@ -76,13 +77,23 @@ def command_extract(args):
         )
         sys.exit(1)
 
+    if workflows is not None and output_origin == "sonarqube":
+        logger.error(
+            'Error: The parameter "-wf" must accompany a github repository output'
+        )
+        print_warn(
+            'Error: The parameter "-wf" must accompany a github repository output'
+        )
+        sys.exit(1)
+
     console = Console()
     console.clear()
     print_rule("Extract metrics")
     parser = GenericParser()
 
     if repository_path and output_origin == "github":
-        filters = {"labels": label if label else "US,User Story,User Stories"}
+        filters = {"labels": label if label else "US,User Story,User Stories",
+                   "workflows": workflows if workflows else None}
         result = parser.parse(
             input_value=repository_path, type_input=output_origin, filters=filters
         )

--- a/src/cli/parsers.py
+++ b/src/cli/parsers.py
@@ -122,6 +122,13 @@ def create_parser():
         help="Path to analysis git repository",
     )
 
+    parser_extract.add_argument(
+        "-wf",
+        "--workflows",
+        type=list,
+        help="A list of workflow names to be considered in the ci feedback time calculation",
+    )
+
     parser_extract.set_defaults(func=command_extract)  # function command extract
 
     # =====================================< COMMAND calculate >=====================================


### PR DESCRIPTION
## Descrição
Este pull request resolve parte do BUG007, adicionando a flag "-wf" para selecionar os nomes dos workflows a serem utilizados.

[BUG007 - Corrigir modo de consulta de workflows para CI_feedback_time](https://github.com/fga-eps-mds/2024.1-MeasureSoftGram-DOC/issues/58)

## Porque este Pull Request é necessário?
As razões desse PR estão listadas na issue.

## Critérios de aceitação
- [x] O usuáriao deve ser capaz de utilizar a flag -wf e passar uma lista de nomes de workflows que serão considerados no cálculo da soma do feedback time.

1. [x] Todas as informações necessárias estão presentes?
2. [x] O documento está escrito de forma concisa?
3. [x] A ortografia do documento está correta?

