### PR TITLE
ENH002 - Filtrar por data medidas de Throughput do GitHub no CLI

### DIFF
--- a/src/cli/commands/cmd_extract.py
+++ b/src/cli/commands/cmd_extract.py
@@ -100,9 +100,11 @@ def command_extract(args):
     parser = GenericParser()
 
     if repository_path and output_origin == "github":
-        filters = {"labels": label if label else "US,User Story,User Stories",
-                   "workflows": workflows if workflows else None,
-                   "dates": filter_date if filter_date else None}
+        filters = {
+            "labels": label if label else "US,User Story,User Stories",
+            "workflows": workflows if workflows else None,
+            "dates": filter_date if filter_date else None,
+        }
         result = parser.parse(
             input_value=repository_path, type_input=output_origin, filters=filters
         )

--- a/src/cli/parsers.py
+++ b/src/cli/parsers.py
@@ -103,7 +103,23 @@ def create_parser():
         type=str,
         help=(
             "Selected label name for extracted user story issues. Format 'XX YY'."
-            + " Default values, not case sensitive: 'US', 'User Story' or 'User Stories'"
+            + " Default, not case sensitive: 'US', 'User Story' or 'User Stories'"
+        ),
+    )
+
+    parser_extract.add_argument(
+        "-wf",
+        "--workflows",
+        type=list,
+        help="Selected workflow name to be considered in the CI Feedback Time extraction. Default: 'build'",
+    )
+
+    parser_extract.add_argument(
+        "-fd",
+        "--filter_date",
+        type=str,
+        help=(
+            "Filter range of dates considered on extraction, with format 'dd/mm/yyyy-dd/mm/yyyy'"
         ),
     )
 
@@ -120,13 +136,6 @@ def create_parser():
         "--repository_path",
         type=str,
         help="Path to analysis git repository",
-    )
-
-    parser_extract.add_argument(
-        "-wf",
-        "--workflows",
-        type=list,
-        help="A list of workflow names to be considered in the ci feedback time calculation",
     )
 
     parser_extract.set_defaults(func=command_extract)  # function command extract

--- a/src/cli/utils.py
+++ b/src/cli/utils.py
@@ -1,4 +1,6 @@
 import logging
+import re
+from datetime import datetime
 
 from rich import box, print
 from rich.console import Console
@@ -8,6 +10,24 @@ from rich.table import Table
 
 logger = logging.getLogger("msgram")
 console = Console(highlight=False, soft_wrap=False, width=140)
+
+DATE_PATTERN = r"^\d{2}/\d{2}/\d{4}-\d{2}/\d{2}/\d{4}$"
+
+
+def is_valid_date_range(date):
+    match = re.match(DATE_PATTERN, date)
+    if not match:
+        return False
+
+    d1, m1, y1, d2, m2, y2 = [int(time) for time in re.split(r'[/\-]', date)]
+
+    try:
+        since = datetime(y1, m1, d1)
+        until = datetime(y2, m2, d2)
+    except ValueError:
+        return False
+
+    return since <= until
 
 
 def print_info(text: str):

--- a/src/cli/utils.py
+++ b/src/cli/utils.py
@@ -19,7 +19,7 @@ def is_valid_date_range(date):
     if not match:
         return False
 
-    d1, m1, y1, d2, m2, y2 = [int(time) for time in re.split(r'[/\-]', date)]
+    d1, m1, y1, d2, m2, y2 = [int(time) for time in re.split(r"[/\-]", date)]
 
     try:
         since = datetime(y1, m1, d1)

--- a/tests/unit/test_extract.py
+++ b/tests/unit/test_extract.py
@@ -114,6 +114,98 @@ def test_extract_fail_no_dp_or_rep():
     )
 
 
+def test_extract_fail_sonarqube_wf():
+    extract_dirpath = tempfile.mkdtemp()
+    args = {
+        "output_origin": "sonarqube",
+        "language_extension": "py",
+        "extracted_path": Path(extract_dirpath),
+        "repository_path": "fga-eps-mds/2023-1-MeasureSoftGram-DOC",
+        "workflows": "pages build and deployment",
+    }
+
+    captured_output = StringIO()
+    sys.stdout = captured_output
+    with pytest.raises(SystemExit):
+        command_extract(args)
+
+    sys.stdout = sys.__stdout__
+
+    assert (
+        'Error: The parameter "-wf" must accompany a github repository output'
+        in captured_output.getvalue()
+    )
+
+
+def test_extract_fail_sonarqube_lb():
+    extract_dirpath = tempfile.mkdtemp()
+    args = {
+        "output_origin": "sonarqube",
+        "language_extension": "py",
+        "extracted_path": Path(extract_dirpath),
+        "repository_path": "fga-eps-mds/2023-1-MeasureSoftGram-DOC",
+        "label": "US",
+    }
+
+    captured_output = StringIO()
+    sys.stdout = captured_output
+    with pytest.raises(SystemExit):
+        command_extract(args)
+
+    sys.stdout = sys.__stdout__
+
+    assert (
+        'Error: The parameter "-lb" must accompany a github repository output'
+        in captured_output.getvalue()
+    )
+
+
+def test_extract_fail_sonarqube_fd():
+    extract_dirpath = tempfile.mkdtemp()
+    args = {
+        "output_origin": "sonarqube",
+        "language_extension": "py",
+        "extracted_path": Path(extract_dirpath),
+        "repository_path": "fga-eps-mds/2023-1-MeasureSoftGram-DOC",
+        "filter_date": "20/06/2023-15/07/2023",
+    }
+
+    captured_output = StringIO()
+    sys.stdout = captured_output
+    with pytest.raises(SystemExit):
+        command_extract(args)
+
+    sys.stdout = sys.__stdout__
+
+    assert (
+        'Error: The parameter "-fd" must accompany a github repository output'
+        in captured_output.getvalue()
+    )
+
+
+def test_extract_fail_date_format():
+    extract_dirpath = tempfile.mkdtemp()
+    args = {
+        "output_origin": "github",
+        "language_extension": "py",
+        "extracted_path": Path(extract_dirpath),
+        "repository_path": "fga-eps-mds/2023-1-MeasureSoftGram-DOC",
+        "filter_date": "20/06/2023-15/07/2021",
+    }
+
+    captured_output = StringIO()
+    sys.stdout = captured_output
+    with pytest.raises(SystemExit):
+        command_extract(args)
+
+    sys.stdout = sys.__stdout__
+
+    assert (
+        "Error: Range of dates for filter must be in format 'dd/mm/yyyy-dd/mm/yyyy'"
+        in captured_output.getvalue()
+    )
+
+
 def test_extract_directory_not_exist():
     args = {
         "output_origin": "sonarqube",


### PR DESCRIPTION
## Descrição
Atualmente, a utilização da API do Github para buscar as medidas do Throughput buscam por todas as issues do repositório em questão na API do Github. Como melhoria, devemos trazer um parâmetro para limitar essa busca dentro de um período de datas.

[ENH002](https://github.com/fga-eps-mds/2024.1-MeasureSoftGram-DOC/issues/64)

## Porque este Pull Request é necessário?
Com essa alteração, utilizaremos um parâmetro para realizar a busca correta por todas as issues que serão utilizadas na extração de medidas para o Throughput, limitadas nesse período de tempo.

## Critérios de aceitação

- [x] Após a alteração, a busca deve estar considerando apenas issues que possuam:
    - Data de criação anterior à data final inserida no período
    - Data de fechamento posterior à data inicial inserida no período, caso a data de fechamento exista. Caso não exista, a issue é considerada.
- [x] Deverão haver testes para garantir o funcionamento

Closes #64
