### PR TITLE
bug/008: Alteração para separação entre Github e Sonar no comando calculate

### DIFF
--- a/src/cli/aggregate_metrics.py
+++ b/src/cli/aggregate_metrics.py
@@ -24,7 +24,7 @@ metrics["github"] = [
 ]
 
 measures = {}
-measures["sonar"] = [
+measures["sonarqube"] = [
     "passed_tests",
     "test_builds",
     "test_errors",
@@ -37,22 +37,13 @@ measures["sonar"] = [
 measures["github"] = ["team_throughput", "ci_feedback_time"]
 
 
-def should_process_sonar_metrics(config):
+def should_process_metrics(input_format, config):
     for characteristic in config.get("characteristics", []):
         for subcharacteristic in characteristic.get("subcharacteristics", []):
             for measure in subcharacteristic.get("measures", []):
-                if measure.get("key") in measures["sonar"]:
-                    return True
-    return False
-
-
-def should_process_github_metrics(config):
-    for characteristic in config.get("characteristics", []):
-        for subcharacteristic in characteristic.get("subcharacteristics", []):
-            for measure in subcharacteristic.get("measures", []):
-                if measure.get("key") in measures["github"]:
-                    return True
-    return False
+                if measure.get("key") not in measures[input_format]:
+                    return False
+    return True
 
 
 def read_msgram(file_path):
@@ -96,78 +87,20 @@ def save_metrics(file_name, metrics):
     print_info(f"> [blue] Metrics saved to: {output_file_path}\n")
 
 
-def process_sonar_metrics(folder_path, msgram_files, github_files):
+def process_metrics(folder_path, msgram_files):
     processed_files = []
 
     for file in msgram_files:
-        if file not in github_files:
-            print_info(f"> [blue] Processing {file}")
-            sonar_metrics_dict = read_msgram(os.path.join(folder_path, file))
+        print_info(f"> [blue] Processing {file}")
+        metrics_dict = read_msgram(os.path.join(folder_path, file))
 
-            if not sonar_metrics_dict:
-                print_error(f"> [red] Error to read sonar metrics in: {folder_path}\n")
-                return False
+        if not metrics_dict:
+            print_error(f"> [red] Error to read metrics in: {folder_path}\n")
+            return False
 
-            processed_files.append((file, sonar_metrics_dict))
+        processed_files.append((file, metrics_dict))
 
     return processed_files
-
-
-def process_github_metrics(folder_path, github_files, metrics):
-    if not github_files:
-        print_error(f"> [red] GitHub files not found in the directory: {folder_path}\n")
-        return False
-
-    print_info(f"> [blue] GitHub metrics found in: {folder_path}\n")
-
-    github_metrics_list = []
-
-    for github_file_name in github_files:
-        github_file_path = os.path.join(folder_path, github_file_name)
-        github_file_content = read_msgram(github_file_path)
-
-        if not github_file_content:
-            print_error(
-                f"> [red] Error to read github metrics in: {github_file_path}\n"
-            )
-            continue
-
-        github_key = next(iter(github_file_content.keys() - metrics["sonar"]), "")
-
-        github_metrics = [
-            {
-                "metric": metric,
-                "value": next(
-                    (
-                        m["value"]
-                        for m in github_file_content[github_key]
-                        if m["metric"] == metric
-                    ),
-                    None,
-                ),
-            }
-            for metric in metrics["github"]
-        ]
-
-        github_metrics_list.append((github_file_name, github_metrics))
-
-    return github_metrics_list
-
-
-def find_common_part(sonar_filename, github_result):
-    sonar_filename_root, _ = os.path.splitext(sonar_filename)
-
-    sonar_parts = sonar_filename_root.split("-")
-    if len(sonar_parts) >= 7:
-        sonar_key = "-".join(sonar_parts[:7])
-
-        for github_filename, github_metrics in github_result:
-            github_filename_root, _ = os.path.splitext(github_filename)
-
-            if sonar_key in github_filename_root:
-                return github_metrics
-
-    return False
 
 
 def aggregate_metrics(input_format, folder_path, config: json):
@@ -178,56 +111,43 @@ def aggregate_metrics(input_format, folder_path, config: json):
         return False
 
     github_files = [file for file in msgram_files if file.startswith("github_")]
-
+    sonar_files = [file for file in msgram_files if file not in github_files]
     file_content = {}
 
-    sonar_result = []
-    github_result = []
+    result = []
 
     have_metrics = False
 
-    config_has_github = should_process_github_metrics(config)
+    if input_format == "github":
+        if should_process_metrics(input_format, config):
+            result = process_metrics(folder_path, github_files)
 
-    if config_has_github and input_format == "github":
-        github_result = process_github_metrics(folder_path, github_files, metrics)
+            if not result:
+                print_error("> [red]Error: Unexpected result from process_github_metrics")
+                return False
 
-        if not github_result:
-            print_error("> [red]Error: Unexpected result from process_github_metrics")
+            have_metrics = True
+        else:
+            print_error("> [red]Error: Unexpected measures from should_process_metrics")
             return False
+    if input_format == "sonarqube":
+        if should_process_metrics(input_format, config):
+            result = process_metrics(folder_path, sonar_files)
 
-        have_metrics = True
-    if should_process_sonar_metrics(config) and input_format == "sonarqube":
-        sonar_result = process_sonar_metrics(folder_path, msgram_files, github_files)
+            if not result:
+                print_error("> [red]Error: Unexpected result from process_sonar_metrics")
+                return False
 
-        if not sonar_result:
-            print_error("> [red]Error: Unexpected result from process_sonar_metrics")
+            have_metrics = True
+        else:
+            print_error("> [red]Error: Unexpected measures from should_process_metrics")
             return False
-
-        have_metrics = True
-
-    print(len(github_result), len(sonar_result))
 
     if not have_metrics:
         print_error(f"> [red]Error: No metrics where found in the .msgram files from the type: {input_format}")
         return False
 
-
-
-
-    for sonar_filename, file_content in sonar_result:
-        github_metrics = find_common_part(sonar_filename, github_result)
-
-        if github_metrics:
-            file_content["github_metrics"] = github_metrics
-        elif config_has_github:
-            print_error(
-                f"> [red]Error: The configuration provided by the user requires github metrics\n"
-                f"  but there was not found github metrics associated with the file:\n"
-                f"  {sonar_filename}"
-            )
-
-            return False
-
-        save_metrics(os.path.join(folder_path, sonar_filename), file_content)
+    for filename, file_content in result:
+        save_metrics(os.path.join(folder_path, filename), file_content)
 
     return True

--- a/src/cli/aggregate_metrics.py
+++ b/src/cli/aggregate_metrics.py
@@ -170,7 +170,7 @@ def find_common_part(sonar_filename, github_result):
     return False
 
 
-def aggregate_metrics(folder_path, config: json):
+def aggregate_metrics(input_format, folder_path, config: json):
     msgram_files = list_msgram_files(folder_path)
 
     if not msgram_files:
@@ -188,7 +188,7 @@ def aggregate_metrics(folder_path, config: json):
 
     config_has_github = should_process_github_metrics(config)
 
-    if config_has_github:
+    if config_has_github and input_format == "github":
         github_result = process_github_metrics(folder_path, github_files, metrics)
 
         if not github_result:
@@ -196,8 +196,7 @@ def aggregate_metrics(folder_path, config: json):
             return False
 
         have_metrics = True
-
-    if should_process_sonar_metrics(config):
+    if should_process_sonar_metrics(config) and input_format == "sonarqube":
         sonar_result = process_sonar_metrics(folder_path, msgram_files, github_files)
 
         if not sonar_result:
@@ -206,9 +205,14 @@ def aggregate_metrics(folder_path, config: json):
 
         have_metrics = True
 
+    print(len(github_result), len(sonar_result))
+
     if not have_metrics:
-        print_error("> [red]Error: No metrics where found in the .msgram files")
+        print_error(f"> [red]Error: No metrics where found in the .msgram files from the type: {input_format}")
         return False
+
+
+
 
     for sonar_filename, file_content in sonar_result:
         github_metrics = find_common_part(sonar_filename, github_result)

--- a/src/cli/commands/cmd_calculate.py
+++ b/src/cli/commands/cmd_calculate.py
@@ -38,9 +38,6 @@ def read_config_file(input_format, config_path):
 def calculate_metrics(input_format, extracted_path, config):
     data_calculated = []
 
-    print('teste: ', extracted_path)
-    print('format: ', input_format)
-
     if not extracted_path.is_file():
         if not aggregate_metrics(input_format, extracted_path, config):
             print_error(
@@ -48,14 +45,17 @@ def calculate_metrics(input_format, extracted_path, config):
             )
             return data_calculated, False
 
-        print('passed\n\n\n')
-        for file, file_name in read_multiple_files(extracted_path, "metrics"):
+        for file, file_name in read_multiple_files(extracted_path, input_format, "metrics"):
+            if file_name.startswith("github_"):
+                file_name = file_name[len("github_"):]
             result = calculate_all(file, file_name, config)
             data_calculated.append(result)
 
         return data_calculated, True
     else:
         try:
+            if extracted_path.name.startswith("github_"):
+                extracted_path.name = extracted_path.name[len("github_"):]
             result = calculate_all(
                 open_json_file(extracted_path), extracted_path.name, config
             )

--- a/src/cli/commands/cmd_calculate.py
+++ b/src/cli/commands/cmd_calculate.py
@@ -18,7 +18,7 @@ from src.cli.resources.subcharacteristic import calculate_subcharacteristics
 from src.cli.utils import print_error, print_info, print_panel, print_rule, print_table
 from src.cli.aggregate_metrics import aggregate_metrics
 from src.cli.exceptions import exceptions
-from src.config.settings import DEFAULT_CONFIG_PATH, FILE_CONFIG
+from src.config.settings import DEFAULT_CONFIG_PATH, FILE_CONFIG_GITHUB, FILE_CONFIG_SONARQUBE
 
 logger = logging.getLogger("msgram")
 
@@ -34,11 +34,14 @@ def read_config_file(config_path):
         exit(1)
 
 
-def calculate_metrics(extracted_path, config):
+def calculate_metrics(input_format, extracted_path, config):
     data_calculated = []
 
+    print('teste: ', extracted_path)
+    print('format: ', input_format)
+
     if not extracted_path.is_file():
-        if not aggregate_metrics(extracted_path, config):
+        if not aggregate_metrics(input_format, extracted_path, config):
             print_error(
                 "> [red] Failed to aggregate metrics, calculate was not performed. \n"
             )
@@ -63,6 +66,7 @@ def calculate_metrics(extracted_path, config):
 def command_calculate(args):
     try:
         output_format: str = args["output_format"]
+        input_format: str = args["input_format"]
         config_path = args["config_path"]
         extracted_path = args["extracted_path"]
 
@@ -80,7 +84,7 @@ def command_calculate(args):
 
     print_info("\n> [blue] Reading extracted files:[/]")
 
-    data_calculated, success = calculate_metrics(extracted_path, config)
+    data_calculated, success = calculate_metrics(input_format, extracted_path, config)
 
     if success:
         print_info("\n[#A9A9A9]All calculations performed[/] successfully!")

--- a/src/cli/commands/cmd_calculate.py
+++ b/src/cli/commands/cmd_calculate.py
@@ -23,12 +23,13 @@ from src.config.settings import DEFAULT_CONFIG_PATH, FILE_CONFIG_GITHUB, FILE_CO
 logger = logging.getLogger("msgram")
 
 
-def read_config_file(config_path):
+def read_config_file(input_format, config_path):
     try:
-        return open_json_file(config_path / FILE_CONFIG)
+        config = FILE_CONFIG_SONARQUBE if input_format == "sonarqube" else FILE_CONFIG_GITHUB
+        return open_json_file(config_path / config)
     except exceptions.MeasureSoftGramCLIException as e:
         print_error(
-            f"[red]Error reading msgram.json config file in {config_path}: {e}\n"
+            f"[red]Error reading {config} config file in {config_path}: {e}\n"
         )
         print_rule()
         exit(1)
@@ -47,6 +48,7 @@ def calculate_metrics(input_format, extracted_path, config):
             )
             return data_calculated, False
 
+        print('passed\n\n\n')
         for file, file_name in read_multiple_files(extracted_path, "metrics"):
             result = calculate_all(file, file_name, config)
             data_calculated.append(result)
@@ -80,7 +82,7 @@ def command_calculate(args):
     print_rule("Calculate")
     print_info("> [blue] Reading config file:[/]")
 
-    config = read_config_file(config_path)
+    config = read_config_file(input_format, config_path)
 
     print_info("\n> [blue] Reading extracted files:[/]")
 

--- a/src/cli/jsonReader/jsonReader.py
+++ b/src/cli/jsonReader/jsonReader.py
@@ -29,8 +29,15 @@ def file_reader(path_file):
     return components
 
 
-def read_multiple_files(directory: Path, pattern: str):
-    for path_file in directory.glob(f"*.{pattern}"):
+def read_multiple_files(directory: Path, format: str, pattern: str):
+    if format == "github":
+        glob_pattern = f"github_*.{pattern}"
+    elif format == "sonarqube":
+        glob_pattern = f"[!github_]*.{pattern}"
+    else:
+        glob_pattern = f"*.{pattern}"
+    
+    for path_file in directory.glob(glob_pattern):
         try:
             yield open_json_file(path_file), path_file.name
         except exceptions.MeasureSoftGramCLIException:

--- a/src/cli/parsers.py
+++ b/src/cli/parsers.py
@@ -171,6 +171,15 @@ def create_parser():
     )
 
     parser_calculate.add_argument(
+        "-in",
+        "--input_format",
+        type=str,
+        choices=AVAILABLE_IMPORTS,
+        default="sonarqube",
+        help=("The type of the input (extracted) values is:".join(AVAILABLE_IMPORTS)),
+    )
+
+    parser_calculate.add_argument(
         "-o",
         "--output_format",
         type=str,

--- a/src/cli/parsers.py
+++ b/src/cli/parsers.py
@@ -173,6 +173,7 @@ def create_parser():
     parser_calculate.add_argument(
         "-in",
         "--input_format",
+        required=True,
         type=str,
         choices=AVAILABLE_IMPORTS,
         default="sonarqube",

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+FILE_CONFIG_SONARQUBE = "msgram_sonarqube.json"
+FILE_CONFIG_GITHUB = "msgram_github.json"
 FILE_CONFIG = "msgram.json"
 DEFAULT_CONFIG_PATH = Path.cwd() / ".msgram"
 DEFAULT_RAW_DATA_PATH = Path.cwd() / "analytics-raw-data"


### PR DESCRIPTION
## Descrição
Atualmente, a utilização do comando calculate se baseia na junção entre cálculo do Sonarqube e do GitHub, porém, para seguir os timeframes ideais, devemos realizar a separação entre GitHub e Sonar, que possuem timeframes diferentes.

[BUG008](https://github.com/fga-eps-mds/2024.1-MeasureSoftGram-DOC/issues/59)

## Porque este Pull Request é necessário?
Com essa alteração, realizaremos a divisão da configuração do calculate entre os dois tipos.

## Critérios de aceitação

- [x] Após a alteração, deverão existir dois arquivos de configuração, que serão utilizados para seus devidos tipos de entrada.
- [X] Deverá existir um parâmetro para definir o tipo de entrada.
- [x] Deverão haver testes para garantir o funcionamento

Closes #59
