### PR TITLE
Thiago/refactor/us004

### DIFF
--- a/src/cli/commands/cmd_extract.py
+++ b/src/cli/commands/cmd_extract.py
@@ -102,7 +102,7 @@ def command_extract(args):
     if repository_path and output_origin == "github":
         filters = {
             "labels": label if label else "US,User Story,User Stories",
-            "workflows": workflows.split(',') if workflows else "build",
+            "workflows": workflows.split(",") if workflows else "build",
             "dates": filter_date if filter_date else None,
         }
         result = parser.parse(

--- a/src/cli/commands/cmd_norm_diff.py
+++ b/src/cli/commands/cmd_norm_diff.py
@@ -43,15 +43,15 @@ def read_calculated_file(file_path):
 
 def command_norm_diff(args):
     try:
-        planned_path = args["planned_path"]
-        calculated_path = args["calculated_path"]
+        rp_path = args["rp_path"]
+        rd_path = args["rd_path"]
     except KeyError as e:
         logger.error(f"KeyError: args[{e}] - non-existent parameters")
         print_error(f"KeyError: args[{e}] - non-existent parameters")
         exit(1)
 
-    planned_data = read_planned_file(planned_path, sort_key="key")
-    calculated_data = read_calculated_file(calculated_path)
+    planned_data = read_planned_file(rp_path, sort_key="key")
+    calculated_data = read_calculated_file(rd_path)
 
     planned_vector, calculated_vector = extract_values(planned_data, calculated_data)
     norm_diff_value = norm_diff(planned_vector, calculated_vector)

--- a/src/cli/commands/cmd_norm_diff.py
+++ b/src/cli/commands/cmd_norm_diff.py
@@ -56,8 +56,8 @@ def command_norm_diff(args):
     planned_vector, calculated_vector = extract_values(planned_data, calculated_data)
     norm_diff_value = norm_diff(planned_vector, calculated_vector)
 
-    print_info("\n[#A9A9A9]Norm diff calculation performed successfully![/]")
-    print_info("[#A9A9A9]For more detailed information use 'diff' command.[/]\n")
+    print_info("\n[#A9A9A9]Norm diff calculation performed successfully![/]\n")
+    print_info("[#A9A9A9]The norm_diff value indicates the difference between the observed quality (Rd) and the planned target (Rp). A norm_diff of 0 means that the observed quality perfectly aligns with the planned target. If norm_diff is not equal to 0, it shows a deviation from the target. In this case, you should determine whether the performance is above or below the planned quality. For a detailed analysis of these differences, use the msgram diff command.[/]\n")
     print(f"Norm Diff: {norm_diff_value}")
     print_rule()
 

--- a/src/cli/commands/cmd_norm_diff.py
+++ b/src/cli/commands/cmd_norm_diff.py
@@ -53,7 +53,7 @@ def command_norm_diff(args):
     planned_data = read_planned_file(rp_path, sort_key="key")
     calculated_data = read_calculated_file(rd_path)
 
-    planned_vector, calculated_vector = extract_values(planned_data, calculated_data)
+    planned_vector, calculated_vector = extract_values(planned_data, calculated_data, rp_path, rd_path)
     norm_diff_value = norm_diff(planned_vector, calculated_vector)
 
     print_info("\n[#A9A9A9]Norm diff calculation performed successfully![/]\n")
@@ -62,7 +62,7 @@ def command_norm_diff(args):
     print_rule()
 
 
-def extract_values(planned_data, calculated_data):
+def extract_values(planned_data, calculated_data, rp_path, rd_path):
     try:
         planned = planned_data
         calculated = []
@@ -86,6 +86,18 @@ def extract_values(planned_data, calculated_data):
         planned_values = [planned_dict[key] for key in planned_keys]
         calculated_values = [calculated_dict[key] for key in planned_keys]
 
+        for value in planned_values:
+            if value > 1:
+                print_error(f"[red]The values informed in the .json file {rp_path} must be between 0 and 1.\n")
+                print_rule()
+                exit(1)
+
+        for value in calculated_values:
+            if value > 1:
+                print_error(f"[red]The values informed in the .json file {rd_path} must be between 0 and 1.\n")
+                print_rule()
+                exit(1)
+    
         return (np.array(planned_values), np.array(calculated_values))
     except exceptions.MeasureSoftGramCLIException as e:
         print_error(f"[red]Error extracting values: {e}\n")

--- a/src/cli/commands/cmd_norm_diff.py
+++ b/src/cli/commands/cmd_norm_diff.py
@@ -87,13 +87,13 @@ def extract_values(planned_data, calculated_data, rp_path, rd_path):
         calculated_values = [calculated_dict[key] for key in planned_keys]
 
         for value in planned_values:
-            if value > 1:
+            if value > 1 or value < 0:
                 print_error(f"[red]The values informed in the .json file {rp_path} must be between 0 and 1.\n")
                 print_rule()
                 exit(1)
 
         for value in calculated_values:
-            if value > 1:
+            if value > 1 or value < 0:
                 print_error(f"[red]The values informed in the .json file {rd_path} must be between 0 and 1.\n")
                 print_rule()
                 exit(1)

--- a/src/cli/commands/cmd_norm_diff.py
+++ b/src/cli/commands/cmd_norm_diff.py
@@ -53,11 +53,23 @@ def command_norm_diff(args):
     planned_data = read_planned_file(rp_path, sort_key="key")
     calculated_data = read_calculated_file(rd_path)
 
-    planned_vector, calculated_vector = extract_values(planned_data, calculated_data, rp_path, rd_path)
+    planned_vector, calculated_vector = extract_values(
+        planned_data, calculated_data, rp_path, rd_path
+    )
     norm_diff_value = norm_diff(planned_vector, calculated_vector)
 
     print_info("\n[#A9A9A9]Norm diff calculation performed successfully![/]\n")
-    print_info("[#A9A9A9]The norm_diff value indicates the difference between the observed quality (Rd) and the planned target (Rp). A norm_diff of 0 means that the observed quality perfectly aligns with the planned target. If norm_diff is not equal to 0, it shows a deviation from the target. In this case, you should determine whether the performance is above or below the planned quality. For a detailed analysis of these differences, use the msgram diff command.[/]\n")
+
+    print_info(
+        "[#A9A9A9]The norm_diff value indicates the difference between the observed "
+        "quality (Rd) and the planned target (Rp). A norm_diff of 0 means that the "
+        "observed quality perfectly aligns with the planned target. If norm_diff is "
+        "not equal to 0, it shows a deviation from the target. In this case, you "
+        "should determine whether the performance is above or below the planned "
+        "quality. For a detailed analysis of these differences, use the msgram diff "
+        "command.[/]\n"
+    )
+
     print(f"Norm Diff: {norm_diff_value}")
     print_rule()
 
@@ -88,16 +100,20 @@ def extract_values(planned_data, calculated_data, rp_path, rd_path):
 
         for value in planned_values:
             if value > 1 or value < 0:
-                print_error(f"[red]The values informed in the .json file {rp_path} must be between 0 and 1.\n")
+                print_error(
+                    f"[red]The values informed in the .json file {rp_path} must be between 0 and 1.\n"
+                )
                 print_rule()
                 exit(1)
 
         for value in calculated_values:
             if value > 1 or value < 0:
-                print_error(f"[red]The values informed in the .json file {rd_path} must be between 0 and 1.\n")
+                print_error(
+                    f"[red]The values informed in the .json file {rd_path} must be between 0 and 1.\n"
+                )
                 print_rule()
                 exit(1)
-    
+
         return (np.array(planned_values), np.array(calculated_values))
     except exceptions.MeasureSoftGramCLIException as e:
         print_error(f"[red]Error extracting values: {e}\n")

--- a/src/cli/commands/cmd_norm_diff.py
+++ b/src/cli/commands/cmd_norm_diff.py
@@ -57,7 +57,7 @@ def command_norm_diff(args):
     norm_diff_value = norm_diff(planned_vector, calculated_vector)
 
     print_info("\n[#A9A9A9]Norm diff calculation performed successfully![/]")
-    print_info("[#A9A9A9]For more detailed informations use 'diff' command.[/]")
+    print_info("[#A9A9A9]For more detailed information use 'diff' command.[/]\n")
     print(f"Norm Diff: {norm_diff_value}")
     print_rule()
 

--- a/src/cli/parsers.py
+++ b/src/cli/parsers.py
@@ -180,9 +180,9 @@ def create_parser():
     )
     parser_calculate.set_defaults(func=command_calculate)  # function command calculate
 
-    # =====================================< COMMAND norm-diff >=====================================
+    # =====================================< COMMAND norm_diff >=====================================
     parser_norm_diff = subparsers.add_parser(
-        "norm-diff",
+        "norm_diff",
         help="Calculate the norm difference between the planned metrics and the developed.",
     )
 

--- a/src/cli/parsers.py
+++ b/src/cli/parsers.py
@@ -187,17 +187,17 @@ def create_parser():
     )
 
     parser_norm_diff.add_argument(
-        "-p",
-        "--planned_path",
+        "-rp",
+        "--rp_path",
         type=lambda p: Path(p).absolute(),
-        help="Path to the json with the planned metrics.",
+        help="Path to the .json file with the planned/wished values ​​for the quality characteristics of a release. Quality requirements goals for a release.",
     )
 
     parser_norm_diff.add_argument(
-        "-c",
-        "--calculated_path",
+        "-rd",
+        "--rd_path",
         type=lambda p: Path(p).absolute(),
-        help="Path to the json with the calculated metrics.",
+        help="Path to the .json file with the model-calculated values ​​for a release's quality characteristics observed/developed.",
     )
 
     parser_norm_diff.set_defaults(

--- a/src/cli/parsers.py
+++ b/src/cli/parsers.py
@@ -190,14 +190,16 @@ def create_parser():
         "-rp",
         "--rp_path",
         type=lambda p: Path(p).absolute(),
-        help="Path to the .json file with the planned/wished values ​​for the quality characteristics of a release. Quality requirements goals for a release.",
+        help="Path to the .json file with the planned/wished values ​​for the quality "
+        "characteristics of a release. Quality requirements goals for a release.",
     )
 
     parser_norm_diff.add_argument(
         "-rd",
         "--rd_path",
         type=lambda p: Path(p).absolute(),
-        help="Path to the .json file with the model-calculated values ​​for a release's quality characteristics observed/developed.",
+        help="Path to the .json file with the model-calculated values ​​for a release's "
+        "quality characteristics observed/developed.",
     )
 
     parser_norm_diff.set_defaults(

--- a/tests/unit/data/calculated-bigger-value.json
+++ b/tests/unit/data/calculated-bigger-value.json
@@ -1,0 +1,52 @@
+[
+    {
+        "repository": [
+            {
+                "key": "repository",
+                "value": "Example Repository"
+            }
+        ],
+        "version": [
+            {
+                "key": "version",
+                "value": "27-07-2024-21-40"
+            }
+        ],
+        "measures": [
+            {
+                "key": "first_measure",
+                "value": 1.0
+            },
+            {
+                "key": "second_measure",
+                "value": 0.9996066627522133
+            }
+        ],
+        "subcharacteristics": [
+            {
+                "key": "first_subcharacteristics",
+                "value": 0.8421061048464034
+            },
+            {
+                "key": "second_subcharacteristics",
+                "value": 0.6415437113263573
+            }
+        ],
+        "characteristics": [
+            {
+                "key": "first_characteristics",
+                "value": 0.8421061048464034
+            },
+            {
+                "key": "second_characteristics",
+                "value": 3.6415437113263573
+            }
+        ],
+        "tsqmi": [
+            {
+                "key": "tsqmi",
+                "value": 0.7485723162667646
+            }
+        ]
+    }
+]

--- a/tests/unit/data/planned-bigger-value.json
+++ b/tests/unit/data/planned-bigger-value.json
@@ -1,0 +1,10 @@
+[
+    {
+      "key": "first_characteristics",
+      "value": 0.95
+    },
+    {
+      "key": "second_characteristics ",
+      "value": 3.95
+    }
+  ]

--- a/tests/unit/test_norm_diff.py
+++ b/tests/unit/test_norm_diff.py
@@ -131,3 +131,52 @@ def test_missmatch_values():
 
     assert excinfo.value.code == 1
     assert "Error extracting values" in output
+
+def test_planned_value_bigger_than_one():
+    config_dirpath = tempfile.mkdtemp()
+
+    captured_output = StringIO()
+    sys.stdout = captured_output
+
+    shutil.copy("tests/unit/data/planned-bigger-value.json", f"{config_dirpath}/planned-bigger-value.json")
+    shutil.copy("tests/unit/data/calculated.json", f"{config_dirpath}/calculated.json")
+
+    with pytest.raises(SystemExit) as excinfo:
+        command_norm_diff(
+            {
+                "rp_path": Path(config_dirpath) / "planned-bigger-value.json",
+                "rd_path": Path(config_dirpath) / "calculated.json",
+            }
+        )
+
+    sys.stdout = sys.__stdout__
+
+    output = captured_output.getvalue()
+
+    assert excinfo.value.code == 1
+    assert "The values informed in the .json" in output
+
+
+def test_developed_value_bigger_than_one():
+    config_dirpath = tempfile.mkdtemp()
+
+    captured_output = StringIO()
+    sys.stdout = captured_output
+
+    shutil.copy("tests/unit/data/planned.json", f"{config_dirpath}/planned.json")
+    shutil.copy("tests/unit/data/calculated-bigger-value.json", f"{config_dirpath}/calculated-bigger-value.json")
+
+    with pytest.raises(SystemExit) as excinfo:
+        command_norm_diff(
+            {
+                "rp_path": Path(config_dirpath) / "planned.json",
+                "rd_path": Path(config_dirpath) / "calculated-bigger-value.json",
+            }
+        )
+
+    sys.stdout = sys.__stdout__
+
+    output = captured_output.getvalue()
+
+    assert excinfo.value.code == 1
+    assert "The values informed in the .json" in output

--- a/tests/unit/test_norm_diff.py
+++ b/tests/unit/test_norm_diff.py
@@ -29,7 +29,10 @@ def test_norm_diff():
     output = captured_output.getvalue()
 
     assert "Norm diff calculation performed successfully!" in output
-    assert "The norm_diff value indicates the difference between the observed quality (Rd) and the planned target (Rp)." in output
+    assert (
+        "The norm_diff value indicates the difference between the observed quality (Rd) and the planned target (Rp)."
+        in output
+    )
 
     norm_diff_value = float(output.split("Norm Diff:")[1].split("\n")[0].strip())
     assert norm_diff_value == 0.24323122001478284
@@ -132,13 +135,17 @@ def test_missmatch_values():
     assert excinfo.value.code == 1
     assert "Error extracting values" in output
 
+
 def test_planned_value_not_between_one_and_zero():
     config_dirpath = tempfile.mkdtemp()
 
     captured_output = StringIO()
     sys.stdout = captured_output
 
-    shutil.copy("tests/unit/data/planned-bigger-value.json", f"{config_dirpath}/planned-bigger-value.json")
+    shutil.copy(
+        "tests/unit/data/planned-bigger-value.json",
+        f"{config_dirpath}/planned-bigger-value.json",
+    )
     shutil.copy("tests/unit/data/calculated.json", f"{config_dirpath}/calculated.json")
 
     with pytest.raises(SystemExit) as excinfo:
@@ -164,7 +171,10 @@ def test_developed_value_not_between_one_and_zero():
     sys.stdout = captured_output
 
     shutil.copy("tests/unit/data/planned.json", f"{config_dirpath}/planned.json")
-    shutil.copy("tests/unit/data/calculated-bigger-value.json", f"{config_dirpath}/calculated-bigger-value.json")
+    shutil.copy(
+        "tests/unit/data/calculated-bigger-value.json",
+        f"{config_dirpath}/calculated-bigger-value.json",
+    )
 
     with pytest.raises(SystemExit) as excinfo:
         command_norm_diff(

--- a/tests/unit/test_norm_diff.py
+++ b/tests/unit/test_norm_diff.py
@@ -19,8 +19,8 @@ def test_norm_diff():
 
     command_norm_diff(
         {
-            "planned_path": Path(config_dirpath) / "planned.json",
-            "calculated_path": Path(config_dirpath) / "calculated.json",
+            "rp_path": Path(config_dirpath) / "planned.json",
+            "rd_path": Path(config_dirpath) / "calculated.json",
         }
     )
 
@@ -45,7 +45,7 @@ def test_missing_args():
     shutil.copy("tests/unit/data/calculated.json", f"{config_dirpath}/calculated.json")
 
     with pytest.raises(SystemExit) as excinfo:
-        command_norm_diff({"planned_path": Path(config_dirpath) / "planned.json"})
+        command_norm_diff({"rp_path": Path(config_dirpath) / "planned.json"})
 
     sys.stdout = sys.__stdout__
 
@@ -67,8 +67,8 @@ def test_invalid_calculated_file():
     with pytest.raises(SystemExit) as excinfo:
         command_norm_diff(
             {
-                "planned_path": Path(config_dirpath) / "planned.json",
-                "calculated_path": Path(config_dirpath) / "invalid.json",
+                "rp_path": Path(config_dirpath) / "planned.json",
+                "rd_path": Path(config_dirpath) / "invalid.json",
             }
         )
 
@@ -92,8 +92,8 @@ def test_invalid_planned_file():
     with pytest.raises(SystemExit) as excinfo:
         command_norm_diff(
             {
-                "planned_path": Path(config_dirpath) / "invalid.json",
-                "calculated_path": Path(config_dirpath) / "calculated.json",
+                "rp_path": Path(config_dirpath) / "invalid.json",
+                "rd_path": Path(config_dirpath) / "calculated.json",
             }
         )
 
@@ -120,8 +120,8 @@ def test_missmatch_values():
     with pytest.raises(SystemExit) as excinfo:
         command_norm_diff(
             {
-                "planned_path": Path(config_dirpath) / "missmatch-planned.json",
-                "calculated_path": Path(config_dirpath) / "calculated.json",
+                "rp_path": Path(config_dirpath) / "missmatch-planned.json",
+                "rd_path": Path(config_dirpath) / "calculated.json",
             }
         )
 

--- a/tests/unit/test_norm_diff.py
+++ b/tests/unit/test_norm_diff.py
@@ -132,7 +132,7 @@ def test_missmatch_values():
     assert excinfo.value.code == 1
     assert "Error extracting values" in output
 
-def test_planned_value_bigger_than_one():
+def test_planned_value_not_between_one_and_zero():
     config_dirpath = tempfile.mkdtemp()
 
     captured_output = StringIO()
@@ -157,7 +157,7 @@ def test_planned_value_bigger_than_one():
     assert "The values informed in the .json" in output
 
 
-def test_developed_value_bigger_than_one():
+def test_developed_value_not_between_one_and_zero():
     config_dirpath = tempfile.mkdtemp()
 
     captured_output = StringIO()

--- a/tests/unit/test_norm_diff.py
+++ b/tests/unit/test_norm_diff.py
@@ -29,7 +29,7 @@ def test_norm_diff():
     output = captured_output.getvalue()
 
     assert "Norm diff calculation performed successfully!" in output
-    assert "For more detailed informations use 'diff' command." in output
+    assert "The norm_diff value indicates the difference between the observed quality (Rd) and the planned target (Rp)." in output
 
     norm_diff_value = float(output.split("Norm Diff:")[1].split("\n")[0].strip())
     assert norm_diff_value == 0.24323122001478284


### PR DESCRIPTION
# Ajusta funcionalidade "norm_diff"

## Descrição
Ajusta funcionalidade "norm_diff".

[US004 - Eu, Paulo, desejo utilizar o norm_diff na cli para que eu consiga ver a diferenca entre release planejada e realizada](https://github.com/fga-eps-mds/2024.1-MeasureSoftGram-DOC/issues/51)

## Critérios de aceitação
(Exemplos de critérios de aceitação)

1. [x] Deve ser possível digitar um comando na CLI para imprimir o valor do norm_diff no terminal
2. [x] Deve ser possível colocar os valores esperados no arquivo "planned.json"
3. [x] O sistema deve aceitar apenas valores numérios compreendidos no intervalo fechado entre 0 e 1 [0,1]. Caso os valores informados no arquivo planned.json forem diferentes do esperado, o sistema deve exibir a mensagem de erro: "The values ​​informed in the .json file [file_name] must be between 0 and 1"
4. [x] O valor valor calculado deve estar de acordo com a seguinte formula: `||rp - rd|| / ||rp||`
5. [x] Retornar erro "failed to decode the JSON file" quando o arquivo passado no -rp ou no -rd estiverem em um formato invalido

Closes #51
