### PR TITLE
Fix BUG039 - calculate does not generate output for csv

### DIFF
--- a/src/cli/commands/cmd_calculate.py
+++ b/src/cli/commands/cmd_calculate.py
@@ -59,7 +59,8 @@ def calculate_metrics(input_format, extracted_path, config):
             if extracted_path.name.startswith("github_"):
                 file_name = file_name[len("github_") :]
             result = calculate_all(open_json_file(extracted_path), file_name, config)
-            return result, True
+            data_calculated.append(result)
+            return data_calculated, True
         except exceptions.MeasureSoftGramCLIException as e:
             print_error(f"[red]Error calculating {extracted_path}: {e}\n")
             return data_calculated, False
@@ -140,13 +141,13 @@ def calculate_all(json_data, file_name, config):
 def show_results(output_format, data_calculated, config_path):
 
     if output_format == "tabular":
-        show_tabulate(data_calculated)
+        show_tabulate(data_calculated[0])
 
     elif output_format == "raw":
-        print(data_calculated)
+        print(data_calculated[0])
 
     elif output_format == "tree":
-        show_tree(data_calculated, pre_config)
+        show_tree(data_calculated[0], pre_config)
 
     elif len(data_calculated) == 0:
         print_info(

--- a/tests/unit/data/calc_msgram_exp_github_output.csv
+++ b/tests/unit/data/calc_msgram_exp_github_output.csv
@@ -1,0 +1,2 @@
+repository,version,team_throughput,ci_feedback_time,maturity,functional_completeness,reliability,functional_suitability,tsqmi
+fga-eps-mds-2024.1-MeasureSoftGram-DOC,28-07-2024-00-00,0.0,0.03225806451612903,0.03225806451612903,0.0,0.03225806451612903,0.0,0.023147764246074717

--- a/tests/unit/data/calc_msgram_exp_github_output.json
+++ b/tests/unit/data/calc_msgram_exp_github_output.json
@@ -1,0 +1,52 @@
+[
+    {
+        "repository": [
+            {
+                "key": "repository",
+                "value": "fga-eps-mds-2024.1-MeasureSoftGram-DOC"
+            }
+        ],
+        "version": [
+            {
+                "key": "version",
+                "value": "28-07-2024-00-00"
+            }
+        ],
+        "measures": [
+            {
+                "key": "team_throughput",
+                "value": 0.0
+            },
+            {
+                "key": "ci_feedback_time",
+                "value": 0.03225806451612903
+            }
+        ],
+        "subcharacteristics": [
+            {
+                "key": "maturity",
+                "value": 0.03225806451612903
+            },
+            {
+                "key": "functional_completeness",
+                "value": 0.0
+            }
+        ],
+        "characteristics": [
+            {
+                "key": "reliability",
+                "value": 0.03225806451612903
+            },
+            {
+                "key": "functional_suitability",
+                "value": 0.0
+            }
+        ],
+        "tsqmi": [
+            {
+                "key": "tsqmi",
+                "value": 0.023147764246074717
+            }
+        ]
+    }
+]

--- a/tests/unit/test_calculate.py
+++ b/tests/unit/test_calculate.py
@@ -6,6 +6,7 @@ import tempfile
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
+import filecmp
 
 import pytest
 
@@ -358,6 +359,36 @@ def test_calculate_csv_output():
 
     output_path = Path(f"{config_dirpath}/calc_msgram.csv")
     assert output_path.stat().st_size > 0
+
+    shutil.rmtree(config_dirpath)
+    shutil.rmtree(extract_dirpath)
+
+
+def test_calculate_json_output():
+    config_dirpath = tempfile.mkdtemp()
+    extract_dirpath = tempfile.mkdtemp()
+
+    shutil.copy("tests/unit/data/msgram.json", f"{config_dirpath}/msgram.json")
+
+    extracted_file_name = "github_fga-eps-mds-2024.1-MeasureSoftGram-DOC-28-07-2024-00-00-22-extracted.metrics"
+    shutil.copy(
+        f"tests/unit/data/{extracted_file_name}",
+        f"{extract_dirpath}/{extracted_file_name}",
+    )
+
+    args = {
+        "input_format": "github",
+        "output_format": "json",
+        "config_path": Path(config_dirpath),
+        "extracted_path": Path(extract_dirpath + f"/{extracted_file_name}"),
+    }
+
+    command_calculate(args)
+
+    output_path = Path(f"{config_dirpath}/calc_msgram.json")
+    expected_output = Path("tests/unit/data/calc_msgram_exp_github_output.json")
+    assert output_path.stat().st_size > 0
+    assert filecmp.cmp(output_path, expected_output, shallow=False)
 
     shutil.rmtree(config_dirpath)
     shutil.rmtree(extract_dirpath)

--- a/tests/unit/test_calculate.py
+++ b/tests/unit/test_calculate.py
@@ -358,7 +358,9 @@ def test_calculate_csv_output():
     command_calculate(args)
 
     output_path = Path(f"{config_dirpath}/calc_msgram.csv")
+    expected_output = Path("tests/unit/data/calc_msgram_exp_github_output.csv")
     assert output_path.stat().st_size > 0
+    assert filecmp.cmp(output_path, expected_output, shallow=False)
 
     shutil.rmtree(config_dirpath)
     shutil.rmtree(extract_dirpath)

--- a/tests/unit/test_calculate.py
+++ b/tests/unit/test_calculate.py
@@ -333,3 +333,31 @@ def test_calculate_invalid_extracted_file():
 
     shutil.rmtree(config_dirpath)
     shutil.rmtree(extract_dirpath)
+
+
+def test_calculate_csv_output():
+    config_dirpath = tempfile.mkdtemp()
+    extract_dirpath = tempfile.mkdtemp()
+
+    shutil.copy("tests/unit/data/msgram.json", f"{config_dirpath}/msgram.json")
+
+    extracted_file_name = "github_fga-eps-mds-2024.1-MeasureSoftGram-DOC-28-07-2024-00-00-22-extracted.metrics"
+    shutil.copy(
+        f"tests/unit/data/{extracted_file_name}",
+        f"{extract_dirpath}/{extracted_file_name}",
+    )
+
+    args = {
+        "input_format": "github",
+        "output_format": "csv",
+        "config_path": Path(config_dirpath),
+        "extracted_path": Path(extract_dirpath + f"/{extracted_file_name}"),
+    }
+
+    command_calculate(args)
+
+    output_path = Path(f"{config_dirpath}/calc_msgram.csv")
+    assert output_path.stat().st_size > 0
+
+    shutil.rmtree(config_dirpath)
+    shutil.rmtree(extract_dirpath)


### PR DESCRIPTION
Corrige bug em que o arquivo csv era gerado vazio pelo comando calculate.

Closes #[BUG039](https://github.com/fga-eps-mds/2024.1-MeasureSoftGram-DOC/issues/127)
